### PR TITLE
Fixed the ticker leak

### DIFF
--- a/lib/animate_gradient_widget.dart
+++ b/lib/animate_gradient_widget.dart
@@ -123,6 +123,12 @@ class _AnimateGradientState extends State<AnimateGradient>
       },
     );
   }
+  
+  @override
+  dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
 
   List<ColorTween> getColorTweens() {
     if (widget.primaryColors.length != widget.secondaryColors.length) {


### PR DESCRIPTION
Ticker not disposed of causing a ticker leak. Added the dispose method to dispose of the animation controller before calling super.dispose().

_AnimateGradientState created a Ticker via its TickerProviderStateMixin, but at the time dispose() was called on the mixin, that Ticker was still active. All Tickers must be disposed before calling super.dispose().

Tickers used by AnimationControllers should be disposed by calling dispose() on the AnimationController itself. Otherwise, the ticker will leak.