### PR TITLE
Fixed Exception related to AnimationController disposed

### DIFF
--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -127,7 +127,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -27,25 +27,52 @@ class App extends StatelessWidget {
         title: const Text('Animated Gradient'),
       ),
       body: Center(
-        child: ElevatedButton(
-          onPressed: () {
-            Navigator.push(
-              context,
-              MaterialPageRoute(
-                  builder: (context) => const AnimateGradientScreen()),
-            );
-          },
-          style: ButtonStyle(
-            shape: WidgetStateProperty.all(
-              RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(8),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (context) => const AnimateGradientScreen()),
+                );
+              },
+              style: ButtonStyle(
+                shape: WidgetStateProperty.all(
+                  RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                ),
+              ),
+              child: const Text(
+                'Go to Animated Gradient',
+                style: TextStyle(color: Colors.black),
               ),
             ),
-          ),
-          child: const Text(
-            'Go to Animated Gradient',
-            style: TextStyle(color: Colors.black),
-          ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                      builder: (context) =>
+                          const AnimateGradientControllerScreen()),
+                );
+              },
+              style: ButtonStyle(
+                shape: WidgetStateProperty.all(
+                  RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                ),
+              ),
+              child: const Text(
+                'Go to Animated Gradient Controller',
+                style: TextStyle(color: Colors.black),
+              ),
+            )
+          ],
         ),
       ),
     );
@@ -89,6 +116,128 @@ class _AnimateGradientScreenState extends State<AnimateGradientScreen> {
         secondaryBeginGeometry: const AlignmentDirectional(2, 0),
         secondaryEndGeometry: const AlignmentDirectional(0, -0.8),
         textDirectionForGeometry: TextDirection.rtl,
+        primaryColors: primaryColors,
+        secondaryColors: secondaryColors,
+        child: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Text(
+                'Animated Gradient',
+                style: TextStyle(
+                  fontSize: 36,
+                  color: Colors.white,
+                ),
+              ),
+              ElevatedButton(
+                onPressed: _changeColors,
+                style: _buttonStyle(),
+                child: const Text(
+                  'Change Colors',
+                  style: TextStyle(color: Colors.black),
+                ),
+              )
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  ButtonStyle _buttonStyle() {
+    return ButtonStyle(
+      shape: WidgetStateProperty.all(
+        RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(8),
+        ),
+      ),
+    );
+  }
+
+  void _changeColors() {
+    if (isChanged) {
+      isChanged = false;
+      primaryColors = const [
+        Colors.pink,
+        Colors.pinkAccent,
+        Colors.white,
+      ];
+      secondaryColors = const [
+        Colors.white,
+        Colors.blueAccent,
+        Colors.blue,
+      ];
+    } else {
+      isChanged = true;
+      primaryColors = [
+        Colors.red,
+        Colors.redAccent,
+        Colors.white,
+      ];
+      secondaryColors = [
+        Colors.white,
+        Colors.tealAccent,
+        Colors.teal,
+      ];
+    }
+
+    setState(() {});
+  }
+}
+
+class AnimateGradientControllerScreen extends StatefulWidget {
+  const AnimateGradientControllerScreen({super.key});
+
+  @override
+  State<AnimateGradientControllerScreen> createState() =>
+      _AnimateGradientControllerScreenState();
+}
+
+class _AnimateGradientControllerScreenState
+    extends State<AnimateGradientControllerScreen>
+    with TickerProviderStateMixin {
+  late AnimationController _animationController;
+
+  bool isChanged = false;
+  List<Color> primaryColors = const [
+    Colors.white,
+    Colors.pinkAccent,
+    Colors.pink,
+  ];
+  List<Color> secondaryColors = const [
+    Colors.blue,
+    Colors.blueAccent,
+    Colors.white,
+  ];
+
+  @override
+  void initState() {
+    _animationController =
+        AnimationController(vsync: this, duration: const Duration(seconds: 4));
+
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    _animationController.dispose();
+
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Animated Gradient'),
+      ),
+      body: AnimateGradient(
+        primaryBeginGeometry: const AlignmentDirectional(0, 1),
+        primaryEndGeometry: const AlignmentDirectional(0, 2),
+        secondaryBeginGeometry: const AlignmentDirectional(2, 0),
+        secondaryEndGeometry: const AlignmentDirectional(0, -0.8),
+        textDirectionForGeometry: TextDirection.rtl,
+        controller: _animationController,
         primaryColors: primaryColors,
         secondaryColors: secondaryColors,
         child: Center(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -17,14 +17,49 @@ class MyApp extends StatelessWidget {
   }
 }
 
-class App extends StatefulWidget {
+class App extends StatelessWidget {
   const App({Key? key}) : super(key: key);
 
   @override
-  State<App> createState() => _AppState();
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Animated Gradient'),
+      ),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                  builder: (context) => const AnimateGradientScreen()),
+            );
+          },
+          style: ButtonStyle(
+            shape: WidgetStateProperty.all(
+              RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(8),
+              ),
+            ),
+          ),
+          child: const Text(
+            'Go to Animated Gradient',
+            style: TextStyle(color: Colors.black),
+          ),
+        ),
+      ),
+    );
+  }
 }
 
-class _AppState extends State<App> {
+class AnimateGradientScreen extends StatefulWidget {
+  const AnimateGradientScreen({super.key});
+
+  @override
+  State<AnimateGradientScreen> createState() => _AnimateGradientScreenState();
+}
+
+class _AnimateGradientScreenState extends State<AnimateGradientScreen> {
   bool isChanged = false;
   List<Color> primaryColors = const [
     Colors.white,
@@ -38,8 +73,16 @@ class _AppState extends State<App> {
   ];
 
   @override
+  void dispose() {
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
+      appBar: AppBar(
+        title: const Text('Animated Gradient'),
+      ),
       body: AnimateGradient(
         primaryBeginGeometry: const AlignmentDirectional(0, 1),
         primaryEndGeometry: const AlignmentDirectional(0, 2),
@@ -76,7 +119,7 @@ class _AppState extends State<App> {
 
   ButtonStyle _buttonStyle() {
     return ButtonStyle(
-      shape: MaterialStatePropertyAll(
+      shape: WidgetStateProperty.all(
         RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(8),
         ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -82,6 +82,30 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.4"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.3"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -94,34 +118,34 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.12.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -171,10 +195,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   vector_math:
     dependency: transitive
     description:
@@ -183,14 +207,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
+  vm_service:
     dependency: transitive
     description:
-      name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      name: vm_service
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "14.2.1"
 sdks:
-  dart: ">=3.2.0-194.0.dev <4.0.0"
-  flutter: ">=1.17.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: "none"
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.16.2 <3.0.0"
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   flutter:

--- a/lib/animate_gradient_widget.dart
+++ b/lib/animate_gradient_widget.dart
@@ -2,7 +2,7 @@ part of 'animate_gradient.dart';
 
 class AnimateGradient extends StatefulWidget {
   const AnimateGradient({
-    Key? key,
+    super.key,
     required this.primaryColors,
     required this.secondaryColors,
     this.child,
@@ -20,8 +20,7 @@ class AnimateGradient extends StatefulWidget {
     this.animateAlignments = true,
     this.reverse = true,
   })  : assert(primaryColors.length >= 2),
-        assert(primaryColors.length == secondaryColors.length),
-        super(key: key);
+        assert(primaryColors.length == secondaryColors.length);
 
   /// [controller]: pass this to have a fine control over the [Animation]
   final AnimationController? controller;
@@ -92,8 +91,8 @@ class AnimateGradient extends StatefulWidget {
 
 class _AnimateGradientState extends State<AnimateGradient>
     with TickerProviderStateMixin {
-  late Animation<double> _animation;
-  late AnimationController _controller;
+  AnimationController? _controller;
+  Animation<double>? _animation;
 
   late List<ColorTween> _colorTween;
 
@@ -124,19 +123,21 @@ class _AnimateGradientState extends State<AnimateGradient>
 
   @override
   Widget build(BuildContext context) {
+    final animation = _animation;
+    if (animation == null) return Container();
     return AnimatedBuilder(
-      animation: _animation,
+      animation: animation,
       builder: (BuildContext context, Widget? child) {
         return Container(
           decoration: BoxDecoration(
             gradient: LinearGradient(
               begin: widget.animateAlignments
-                  ? begin.evaluate(_animation)
+                  ? begin.evaluate(animation)
                   : widget.primaryBegin,
               end: widget.animateAlignments
-                  ? end.evaluate(_animation)
+                  ? end.evaluate(animation)
                   : widget.primaryEnd,
-              colors: _evaluateColors(_animation),
+              colors: _evaluateColors(animation),
             ),
           ),
           child: widget.child,
@@ -197,6 +198,7 @@ class _AnimateGradientState extends State<AnimateGradient>
   }
 
   void _setAnimations() {
+    _controller?.dispose();
     _controller = widget.controller ??
         AnimationController(
           vsync: this,
@@ -204,14 +206,14 @@ class _AnimateGradientState extends State<AnimateGradient>
         )
       ..repeat(reverse: widget.reverse);
     _animation = CurvedAnimation(
-      parent: _controller,
+      parent: _controller!,
       curve: Curves.easeInOut,
     );
   }
 
   @override
-  dispose() {
-    _controller.dispose();
+  void dispose() {
+    _controller?.dispose();
     super.dispose();
   }
 }

--- a/lib/animate_gradient_widget.dart
+++ b/lib/animate_gradient_widget.dart
@@ -198,13 +198,20 @@ class _AnimateGradientState extends State<AnimateGradient>
   }
 
   void _setAnimations() {
+    final controller = widget.controller;
+    if (controller != null) {
+      _controller = controller..repeat(reverse: widget.reverse);
+      _animation = CurvedAnimation(
+        parent: _controller!,
+        curve: Curves.easeInOut,
+      );
+      return;
+    }
     _controller?.dispose();
-    _controller = widget.controller ??
-        AnimationController(
-          vsync: this,
-          duration: widget.duration,
-        )
-      ..repeat(reverse: widget.reverse);
+    _controller = AnimationController(
+      vsync: this,
+      duration: widget.duration,
+    )..repeat(reverse: widget.reverse);
     _animation = CurvedAnimation(
       parent: _controller!,
       curve: Curves.easeInOut,
@@ -213,7 +220,10 @@ class _AnimateGradientState extends State<AnimateGradient>
 
   @override
   void dispose() {
-    _controller?.dispose();
+    final controller = widget.controller;
+    if (controller == null) {
+      _controller?.dispose();
+    }
     super.dispose();
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.3
 homepage: https://github.com/Vikaskumar75/Animated-Container
 
 environment:
-  sdk: ">=2.16.2 <3.0.0"
+  sdk: '>=3.0.0 <4.0.0'
   flutter: ">=1.17.0"
 
 dependencies:


### PR DESCRIPTION
I modified the Exception related to AnimationController disposed.
Also I upgraded the sdk version.

```
======== Exception caught by widgets library =======================================================
The following assertion was thrown while finalizing the widget tree:
_AnimateGradientState#8258a(tickers: tracking 1 ticker) was disposed with an active Ticker.

_AnimateGradientState created a Ticker via its TickerProviderStateMixin, but at the time dispose() was called on the mixin, that Ticker was still active. All Tickers must be disposed before calling super.dispose().

Tickers used by AnimationControllers should be disposed by calling dispose() on the AnimationController itself. Otherwise, the ticker will leak.

The offending ticker was: _WidgetTicker(created by _AnimateGradientState#8258a)
The stack trace when the _WidgetTicker was actually created was:
#0      new Ticker.<anonymous closure> (package:flutter/src/scheduler/ticker.dart:71:40)
#1      new Ticker (package:flutter/src/scheduler/ticker.dart:73:6)
```